### PR TITLE
Avoid casting expected to returned type for "assertNotIn"

### DIFF
--- a/saltcheck.py
+++ b/saltcheck.py
@@ -338,7 +338,7 @@ class SaltCheck(object):
             assertion = test_dict['assertion']
             expected_return = test_dict['expected-return']
             actual_return = self.call_salt_command(mod_and_func, args, kwargs)
-            if assertion != "assertIn":
+            if assertion not in ["assertIn", "assertNotIn"]:
                 expected_return = self.cast_expected_to_returned_type(expected_return, actual_return)
             if assertion == "assertEqual":
                 value = self.__assert_equal(expected_return, actual_return)


### PR DESCRIPTION
When providing a unicode string for `expected-return`  to the assertion `assertNotIn` the string is converted into a list before the assert is carried out causing unreliable results. 

This PR ensures `assertNotIn` behaves as `assertIn` does for test operations. 


Example state:
```
remove_user:
  user.absent:
    - name: rawr
    - purge: True
    - force: True
```

Example test:
```
test_user_removed:
  module_and_function: user.list_users
  assertion: assertNotIn
  expected-return: rawr
```