### PR TITLE
Dockerfile: Add wget for ubuntu:16.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,11 @@ MAINTAINER William Cannon
 # Install salt-minion
 # Ref: https://repo.saltstack.com/#ubuntu 
 ############################################################
+# Update repository sources and install wget to pull in SaltStack's GPG key
+RUN apt-get update && apt-get install -y wget
 
 # Add salt repo key
-RUN wget -O - https://repo.saltstack.com/apt/ubuntu/16.04/amd64/latest/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
+RUN wget -O - https://repo.saltstack.com/apt/ubuntu/16.04/amd64/latest/SALTSTACK-GPG-KEY.pub | apt-key add -
 
 # Add salt repo into apt sources
 RUN echo 'deb http://repo.saltstack.com/apt/ubuntu/16.04/amd64/latest xenial main' > /etc/apt/sources.list.d/saltstack.list


### PR DESCRIPTION
This PR will drop the use of sudo for apt-key and install wget to ensure were able to snag SaltStack's GPG key - doesn't appear that they're available in ubuntu:16.04.


```
Step 3/5 : RUN wget -O - https://repo.saltstack.com/apt/ubuntu/16.04/amd64/latest/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
 ---> Running in 38bf59f778a0
/bin/sh: 1: wget: not found
/bin/sh: 1: sudo: not found
```
