### PR TITLE
Avoid duplicate directories in minion cache

### DIFF
--- a/salt/_modules/saltcheck.py
+++ b/salt/_modules/saltcheck.py
@@ -265,9 +265,8 @@ def _refresh_saltcheck_tests_dir(dirpath):
 
     state = mypath_list[-2]
     source = "salt://" + state + os.sep + "saltcheck-tests"
-    dest = mypath_list[:-1]
-    dest = dirpath
-    __salt__['cp.get_dir'](source, dirpath)
+    dest = os.sep + os.sep.join(mypath_list[:-1])
+    __salt__['cp.get_dir'](source, dest)
     return
 
 


### PR DESCRIPTION
Steps to reproduce:

```
$ docker run --add-host=salt:127.0.0.1 --rm -itv $(pwd)/salt:/srv/salt/ -v $(pwd)/pillar:/srv/pillar -v $(pwd)/minion_config/minion:/etc/salt/minion ubuntu16 /bin/bash

# salt-call saltutil.sync_modules
# salt-call saltcheck.run_state_tests apache

# ls -lisa /var/cache/salt/minion/files/base/apache/saltcheck-tests/
total 12
4212 4 drwxr-xr-x 3 root root 4096 Nov 16 02:22 .
4208 4 drwx------ 3 root root 4096 Nov 16 02:22 ..
4213 4 drwxr-xr-x 2 root root 4096 Nov 16 02:22 saltcheck-tests
```