### PR TITLE
add optional assertion_section

### DIFF
--- a/docs/HowTo.txt
+++ b/docs/HowTo.txt
@@ -20,6 +20,7 @@ Input files are simple yaml and have the following syntax:
 
 TEST-ID:
   module_and_function:  SALT-MODULE.SALT_FUNCTION
+  assertion_section: SECTION FROM OUTPUT (optional parameter)
   args: ARG-TO-FUNCTION
   kwargs: KWARGS-TO-FUNCTION
   pillar-data: PILLAR-DATA-ON-THE-FLY

--- a/salt/_modules/saltcheck.py
+++ b/salt/_modules/saltcheck.py
@@ -339,7 +339,8 @@ class SaltCheck(object):
     def call_salt_command(self,
                           fun,
                           args,
-                          kwargs):
+                          kwargs,
+                          assertion_section):
         '''Generic call of salt Caller command'''
         value = False
         try:
@@ -355,7 +356,10 @@ class SaltCheck(object):
             raise
         except Exception:
             raise
-        return value
+        if type(value) == dict and assertion_section:
+            return value.get(assertion_section, False)
+        else:
+            return value
 
     def run_test(self, test_dict):
         '''Run a single saltcheck test'''
@@ -365,11 +369,12 @@ class SaltCheck(object):
             if skip:
                 return {'status': 'Skip', 'duration': 0.0}
             mod_and_func = test_dict['module_and_function']
+            assertion_section = test_dict.get('assertion_section', None)
             args = test_dict.get('args', None)
             kwargs = test_dict.get('kwargs', None)
             assertion = test_dict['assertion']
             expected_return = test_dict.get('expected-return', None)
-            actual_return = self.call_salt_command(mod_and_func, args, kwargs)
+            actual_return = self.call_salt_command(mod_and_func, args, kwargs, assertion_section)
             if assertion not in ["assertIn", "assertNotIn", "assertEmpty", "assertNotEmpty",
                                  "assertTrue", "assertFalse"]:
                 expected_return = self.cast_expected_to_returned_type(expected_return, actual_return)


### PR DESCRIPTION
Parameter assertion_section can be useful to compare only one section from module output 


salt-call user.info vagrant                  
```
local:
    ----------
    fullname:
    gid:
        1004
    groups:
        - docker
        - ssh
        - sudo
        - vagrant
    home:
        /home/vagrant
    homephone:
    name:
        vagrant
    passwd:
        x
    roomnumber:
    shell:
        /bin/bash
    uid:
        1003
    workphone:
```
```check if user vagrant have uid 1003:
  module_and_function: user.info
  assertion_section: 'uid'
  args:
    - vagrant
  assertion: assertEqual
  expected-return: '1003' 
```
```
          check if user vagrant have uid 1003:
              ----------
              duration:
                  0.0016
              status:
                  Pass
```